### PR TITLE
Fix GitRepo methods for new execFile usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 <!-- Add new, unreleased items here. -->
+- Fix gitRepo.fetch() for when no branchName is given
+- Fix gitRepo.getHeadSha() & add tests
 
 ## v1.0.1 [10-05-2017]
 - Update package.json description

--- a/src/git.ts
+++ b/src/git.ts
@@ -33,8 +33,8 @@ export class GitRepo {
   /**
    * Returns the git commit hash at HEAD.
    */
-  async getHeadSha(): Promise<ExecResult> {
-    return await exec(this.dir, 'git', ['rev-parse', 'HEAD']);
+  async getHeadSha(): Promise<string> {
+    return (await exec(this.dir, 'git', ['rev-parse', 'HEAD'])).stdout;
   }
 
   /**
@@ -51,8 +51,10 @@ export class GitRepo {
    * Run `git fetch [remoteName]`. If remoteName is not given, git will fetch
    * from default.
    */
-  async fetch(remoteName: string = ''): Promise<ExecResult> {
-    return await exec(this.dir, 'git', ['fetch', remoteName, '--depth', '1']);
+  async fetch(remoteName?: string): Promise<ExecResult> {
+    const commandArgs = remoteName ? ['fetch', remoteName, '--depth', '1'] :
+                                     ['fetch', '--depth', '1'];
+    return await exec(this.dir, 'git', commandArgs);
   }
 
   /**


### PR DESCRIPTION
Some things were broken by changes to the `exec()` interface/return value. These were caught during polymer-modulizer integration & testing. 

Remote git repo integration tests are still TODO, but I was able to add local tests for `getHeadSha()`.