### PR TITLE
filter out pattern matches missing the #ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- Add new, unreleased items here. -->
 - Fix gitRepo.fetch() for when no branchName is given
 - Fix gitRepo.getHeadSha() & add tests
+- When expanding repo patterns, Filter out repos that don't match the reference branch
 
 ## v1.0.1 [10-05-2017]
 - Update package.json description

--- a/src/test/_util/mock-api.ts
+++ b/src/test/_util/mock-api.ts
@@ -65,9 +65,27 @@ export function setup() {
 
   nock('https://api.github.com')
       .persist()
-      .get('/orgs/polymerelements/repos')
-      .query({page: 1, per_page: 50, access_token: testApiToken})
-      .reply(200, [], {Status: '200 OK'});
+      .get('/repos/PolymerElements/paper-appbar/git/refs/heads/ABCDEFGH')
+      .query({access_token: testApiToken})
+      .reply(200, {ref: 'refs/heads/ABCDEFGH'}, {Status: '200 OK'});
+
+  nock('https://api.github.com')
+      .persist()
+      .get('/repos/PolymerElements/paper-button/git/refs/heads/ABCDEFGH')
+      .query({access_token: testApiToken})
+      .reply(
+          200,
+          [
+            {ref: 'refs/heads/ABCDEFGH-MATCH-1'},
+            {ref: 'refs/heads/ABCDEFGH-MATCH-2'}
+          ],
+          {Status: '200 OK'});
+
+  nock('https://api.github.com')
+      .persist()
+      .get('/repos/PolymerElements/iron-ajax/git/refs/heads/ABCDEFGH')
+      .query({access_token: testApiToken})
+      .reply(200, '', {Status: '404 NOT FOUND'});
 }
 
 export function teardown() {

--- a/src/test/github_test.ts
+++ b/src/test/github_test.ts
@@ -88,64 +88,61 @@ suite('src/github', () => {
       test('handles dynamic owner/*#ref pattern', async () => {
         const references = await githubConnection.expandRepoPatterns(
             ['polymerelements/*#ABCDEFGH']);
-        assert.deepEqual(references, [
-          {
-            owner: 'PolymerElements',
-            name: 'paper-appbar',
-            fullName: 'PolymerElements/paper-appbar',
-            ref: 'ABCDEFGH'
-          },
-          {
-            owner: 'PolymerElements',
-            name: 'paper-button',
-            fullName: 'PolymerElements/paper-button',
-            ref: 'ABCDEFGH'
-          },
-          {
-            owner: 'PolymerElements',
-            name: 'iron-ajax',
-            fullName: 'PolymerElements/iron-ajax',
-            ref: 'ABCDEFGH'
-          }
-        ]);
+        assert.deepEqual(references, [{
+                           owner: 'PolymerElements',
+                           name: 'paper-appbar',
+                           fullName: 'PolymerElements/paper-appbar',
+                           ref: 'ABCDEFGH'
+                         }]);
       });
 
       test('handles dynamic owner/partial-name-* pattern', async () => {
-        const references = await githubConnection.expandRepoPatterns(
-            ['polymerelements/paper-*']);
-        assert.deepEqual(references, [
-          {
-            owner: 'PolymerElements',
-            name: 'paper-appbar',
-            fullName: 'PolymerElements/paper-appbar',
-            ref: undefined
-          },
-          {
-            owner: 'PolymerElements',
-            name: 'paper-button',
-            fullName: 'PolymerElements/paper-button',
-            ref: undefined
-          },
-        ]);
+        assert.deepEqual(
+            await githubConnection.expandRepoPatterns(
+                ['polymerelements/paper-*']),
+            [
+              {
+                owner: 'PolymerElements',
+                name: 'paper-appbar',
+                fullName: 'PolymerElements/paper-appbar',
+                ref: undefined
+              },
+              {
+                owner: 'PolymerElements',
+                name: 'paper-button',
+                fullName: 'PolymerElements/paper-button',
+                ref: undefined
+              },
+            ]);
+        assert.deepEqual(
+            await githubConnection.expandRepoPatterns(
+                ['polymerelements/iron-*']),
+            [
+              {
+                owner: 'PolymerElements',
+                name: 'iron-ajax',
+                fullName: 'PolymerElements/iron-ajax',
+                ref: undefined
+              },
+            ]);
       });
 
       test('handles dynamic owner/partial-name-*#ref pattern', async () => {
-        const references = await githubConnection.expandRepoPatterns(
-            ['polymerelements/paper-*#ABCDEFGH']);
-        assert.deepEqual(references, [
-          {
-            owner: 'PolymerElements',
-            name: 'paper-appbar',
-            fullName: 'PolymerElements/paper-appbar',
-            ref: 'ABCDEFGH'
-          },
-          {
-            owner: 'PolymerElements',
-            name: 'paper-button',
-            fullName: 'PolymerElements/paper-button',
-            ref: 'ABCDEFGH'
-          },
-        ]);
+        assert.deepEqual(
+            await githubConnection.expandRepoPatterns(
+                ['polymerelements/paper-*#ABCDEFGH']),
+            [
+              {
+                owner: 'PolymerElements',
+                name: 'paper-appbar',
+                fullName: 'PolymerElements/paper-appbar',
+                ref: 'ABCDEFGH'
+              },
+            ]);
+        assert.deepEqual(
+            await githubConnection.expandRepoPatterns(
+                ['polymerelements/iron-*#ABCDEFGH']),
+            []);
       });
 
     });

--- a/src/util/bower.ts
+++ b/src/util/bower.ts
@@ -12,9 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {existsSync} from './fs';
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {existsSync} from './fs';
 
 /**
  * @returns a dictionary object of dev dependencies from the bower.json


### PR DESCRIPTION
Currently, patterns like `PolymerElements/*#2.0-preview` will be expanded to include element repos that were never upgraded to Polymer 2.0. These would cause polymer-modulizer conversion to fail on checkout since no 2.0-preview branch existed.

This change assumes that when a reference is given to the matching pattern, the user wants to only match repos with that pattern. This adds an extra API call for each repo expanded, but it saves the user from having to handle false positives.

`modulizer --repo PolymerElements/*#2.0-preview --npm-version 3.0.0-pre.1` now successfully creates the expected workspace.