### PR TITLE
index github api paging at 1, not 0

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -189,7 +189,7 @@ export class GitHubConnection {
     const allRepos: GitHubRepoData[] = [];
     let pageRepos: GitHubRepoData[] = [];
     const pageSize = 50;
-    let page = 0;
+    let page = 1;
     let isOrg = true;
 
     do {

--- a/src/test/_util/mock-api.ts
+++ b/src/test/_util/mock-api.ts
@@ -35,7 +35,7 @@ export function setup() {
   nock('https://api.github.com')
       .persist()
       .get('/orgs/polymerelements/repos')
-      .query({page: 0, per_page: 50, access_token: testApiToken})
+      .query({page: 1, per_page: 50, access_token: testApiToken})
       .reply(
           200,
           [
@@ -62,6 +62,12 @@ export function setup() {
             }
           ],
           {Status: '200 OK'});
+
+  nock('https://api.github.com')
+      .persist()
+      .get('/orgs/polymerelements/repos')
+      .query({page: 2, per_page: 50, access_token: testApiToken})
+      .reply(200, [], {Status: '200 OK'});
 
   nock('https://api.github.com')
       .persist()


### PR DESCRIPTION
\* NEW GITHUB API WEIRDNESS ACHIEVEMENT UNLOCKED \*

Github API paging is indexed starting at page 1, not page zero. But, if you query for page=0, you get page 1 in the response. Because we currently start at page 0 and go on until we see an empty page,  we capture the repo list from page 1 twice (when `page=0|1`).

This PR makes the immediate term fix for the issue, but since the GitHub API asks us not to handle traversal ourselves we should rely on their `Link` headers instead. I've created an issue to track/prioritize that greater refactoring work here: https://github.com/Polymer/polymer-workspaces/issues/9